### PR TITLE
The returned URLs now consider the apps's mountpath, if there is one.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ function addHelper(app, options) {
   app.locals[options.helperName] = function(name, params) {
     var route = app._namedRoutes[name];
     if (!route) throw new Error('Route not found: ' + name);
-    return reverse(app._namedRoutes[name].path, params);
+    var mountpath = (app.mountpath && app.mountpath != '/') ? app.mountpath : '';
+    return mountpath + reverse(app._namedRoutes[name].path, params);
   };
 }
 
@@ -43,7 +44,8 @@ function addMiddleware(app, options) {
         params = routeName;
         routeName = status;
       }
-      var url = reverse(app._namedRoutes[routeName].path, params);
+      var mountpath = (app.mountpath && app.mountpath != '/') ? app.mountpath : ''; 
+      var url = mountpath + reverse(app._namedRoutes[routeName].path, params);
       if (isNaN(status)) return res.redirect(url);
       else return res.redirect(status, url);
     };

--- a/test/index.js
+++ b/test/index.js
@@ -4,11 +4,14 @@ var reverse = require('..');
 
 describe('express-reverse', function() {
   var app;
+  var mountedApp;
   var noop = function(req, res, next) { next(); };
 
   beforeEach(function() {
     app = express();
+    mountedApp = express();
     reverse(app);
+    reverse(mountedApp);
   });
 
   it('should augment express app', function() {
@@ -33,6 +36,21 @@ describe('express-reverse', function() {
     assert.throws(function() { url('test 4'); }, 'Route not found: test 4');
   });
 
+  it('should generate reverse route URLs considering mounted express apps', function() {
+    mountedApp.get('test 1', '/test', noop);
+    mountedApp.get('test 2', '/test/:x', noop);
+    mountedApp.get('test 3', '/test/:x?', noop);
+    app.use('/test-path', mountedApp);
+
+    var url = mountedApp.locals.url;
+    assert.equal(url('test 1'), '/test-path/test');
+    assert.equal(url('test 2', { x: '1' }), '/test-path/test/1');
+    assert.throws(function() { url('test 2'); }, 'Missing value for "x".');
+    assert.equal(url('test 3', { x: '1' }), '/test-path/test/1');
+    assert.equal(url('test 3'), '/test-path/test');
+    assert.throws(function() { url('test 4'); }, 'Route not found: test 4');
+  });
+
   it('should add res.redirectToRoute middleware', function() {
     var middelware;
     app.use = function(fn) { middleware = fn; };
@@ -54,5 +72,29 @@ describe('express-reverse', function() {
     assert.deepEqual(redirectArgs, [301, '/test']);
     res.redirectToRoute('test 2', { x: 1 });
     assert.deepEqual(redirectArgs, ['/test/1']);
+  });
+
+  it('should add res.redirectToRoute middleware considering mounted express apps', function() {
+    var middelware;
+    mountedApp.use = function(fn) { middleware = fn; };
+    reverse(mountedApp);
+    var redirectArgs;
+    var res = {
+      redirect: function() { redirectArgs = Array.prototype.slice.call(arguments, 0); }
+    };
+    middleware(null, res, function() {});
+
+    assert.isDefined(res.redirectToRoute);
+
+    mountedApp.get('test 1', '/test', noop);
+    mountedApp.get('test 2', '/test/:x', noop);
+    app.use('/test-path', mountedApp);
+
+    res.redirectToRoute('test 1');
+    assert.deepEqual(redirectArgs, ['/test-path/test']);
+    res.redirectToRoute(301, 'test 1');
+    assert.deepEqual(redirectArgs, [301, '/test-path/test']);
+    res.redirectToRoute('test 2', { x: 1 });
+    assert.deepEqual(redirectArgs, ['/test-path/test/1']);
   });
 });


### PR DESCRIPTION
The current implementation of express-reverse does not consider the possibility of the app being mounted on top of another app.

For example: I have an express app for an admin interface. It is a completely separate app. On my main project, I include the admin app as follows:

``` javascript
// main app
app.use('/admin', adminApp);
```

``` javascript
// admin app
app.get('edit-user', '/user/:id', function() { '…' });
```

All the routes on the admin app don't know that they are prefixed with '/admin'. In the current implementation, if my admin app tries to use the helper or the middleware, the resulting URL won't consider this.

``` jade
a(href=url('edit-user', {id: user.id})) Edit this user
// yelds: /user/5
// should be: /admin/user/5
```

This pull request changes the helper function and the middleware to prepend the app's mountpath, if there is one. Note that the mountpath is unknown during app setup, so instead of changing the `reverse` function, I've changed the middleware and helper functions.

Two new tests have been included to verify that it works as expected. The current tests, of course, still pass.
