### PR TITLE
Add support for routes with regular expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,19 @@ function addMiddleware(app, options) {
 
 function reverse(path, params) {
   if (!params) params = {};
-  return path.replace(/(\/:\w+\??)/g, function (m, p1) {
-    var required = !~p1.indexOf('?');
-    var param = p1.replace(/[/:?]/g, '');
-    if (required && !params.hasOwnProperty(param))
+  return path.replace(/(\/:(\w+)?(\(.+?\))?(\?)?)/g, function (m, pFull, pName, pRegex, pOptional) {
+    var required = !pOptional;
+    var param = pName;
+    if (required && !params.hasOwnProperty(param)) {
       throw new Error('Missing value for "' + param + '".');
-    return params[param] ? '/' + params[param] : '';
+    }
+
+    var value = params[param];
+    if (pRegex && value) {
+      if (!new RegExp('^' + pRegex + '$').test(value)) {
+        throw new Error('Invalid value for "' + param + '", should match "' + pRegex + '".');
+      }
+    }
+    return value ? '/' + value : '';
   });
 }

--- a/test/index.js
+++ b/test/index.js
@@ -51,6 +51,36 @@ describe('express-reverse', function() {
     assert.throws(function() { url('test 4'); }, 'Route not found: test 4');
   });
 
+  it('should handle reverse route URLs with regular expressions', function() {
+    app.get('regex 1', '/regex/:x(foo|bar)', noop);
+    app.get('regex 2', '/regex/:x1(foo|bar)/:x2(foo1|bar1)', noop);
+    app.get('regex 3', '/regex/:x(foo|bar)?', noop);
+    app.get('regex 4', '/regex/:x([a-z]{1,3})', noop);
+    app.get('regex 5', '/regex/:x([a-z]{1,3})?', noop);
+    app.get('regex 6', '/regex/:x([a-z]+)/:y([0-9]+)', noop);
+    app.get('regex 7', '/regex/:x(fo?o)', noop);
+
+
+    var url = app.locals.url;
+    assert.equal(url('regex 1', { x: 'foo' }), '/regex/foo');
+    assert.equal(url('regex 2', { x1: 'foo', x2: 'bar1' }), '/regex/foo/bar1');
+    assert.equal(url('regex 3', { x: 'foo' }), '/regex/foo');
+    assert.equal(url('regex 3'), '/regex');
+    assert.equal(url('regex 4', { x: 'baz' }), '/regex/baz');
+    assert.throws(function() { url('regex 4', { x: 'foobar' }); },
+                        'Invalid value for "x", should match "([a-z]{1,3})".');
+    assert.equal(url('regex 5'), '/regex');
+    assert.equal(url('regex 5', { x: 'baz' }), '/regex/baz');
+    assert.throws(function() { url('regex 5', { x: 'foobar' }); },
+                        'Invalid value for "x", should match "([a-z]{1,3})".');
+    assert.equal(url('regex 6', { x: 'foobar', y: 1 }), '/regex/foobar/1');
+    assert.throws(function() { url('regex 6', { x: 'foo', y: 'bar' }); },
+                        'Invalid value for "y", should match "([0-9]+)".');
+    assert.equal(url('regex 7', { x: 'fo' }), '/regex/fo');
+    assert.equal(url('regex 7', { x: 'foo' }), '/regex/foo');
+    assert.throws(function() { url('regex 7'); }, 'Missing value for "x".');
+  });
+
   it('should add res.redirectToRoute middleware', function() {
     var middelware;
     app.use = function(fn) { middleware = fn; };


### PR DESCRIPTION
This pull request adds support for advanced routes, such as:

``` javascript
// Route:
'/test/:x1(foo|bar)/:x2/:x3([0-9]+)?'

// Good:
{ x1: 'foo', x2: 'bar' }          // -> /test/foo/bar
{ x1: 'foo', x2: 'bar', x3: 123 } // -> /test/foo/bar/123

// Bad:
{ x1: 'xxx', x2: 'bar', x3: 123 } // Invalid value for "x1", should match "(foo|bar)".
{ x1: 'foo', x2: 'bar', x3: 'a' } // Invalid value for "x3", should match "([0-9]+)".
```

Tests included, with all crucial things covered. :beers: 
